### PR TITLE
fix: symmetric block string delimiters

### DIFF
--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -40,6 +40,7 @@ pub enum Token<'s> {
     BlockCommentOpen,
     BlockCommentClose,
     String(&'s str),
+    BlockStringSymmetric(&'s str),
     BlockStringOpen,
     BlockStringClose,
     Escape,
@@ -53,7 +54,10 @@ macro_rules! define_token_enum {
         line_comment: [ $($line_comment:literal),* $(,)? ],
         block_comment: [ $($block_comment_open:literal => $block_comment_close:literal),* $(,)? ],
         string: [ $($string_delim:literal),* $(,)? ],
-        block_string: [ $($block_string_open:literal => $block_string_close:literal),* $(,)? ]
+        block_string: [
+            $(symmetric $block_string_symmetric:literal),*
+            $($block_string_open:literal => $block_string_close:literal),* $(,)?
+        ]
     }) => {
         #[allow(unused)] // Ignore warnings about unused variants
         #[derive(logos::Logos)]
@@ -76,6 +80,9 @@ macro_rules! define_token_enum {
             $(#[token($string_delim)])*
             String(&'s str),
 
+            $(#[token($block_string_symmetric)])*
+            BlockStringSymmetric(&'s str),
+
             $(#[token($block_string_open)])*
             BlockStringOpen,
 
@@ -95,6 +102,7 @@ macro_rules! define_token_enum {
                     $name::DelimiterOpen(s) => Self::DelimiterOpen(s),
                     $name::DelimiterClose(s) => Self::DelimiterClose(s),
                     $name::LineComment => Self::LineComment,
+                    $name::BlockStringSymmetric(s) => Self::BlockStringSymmetric(s),
                     $name::BlockCommentOpen => Self::BlockCommentOpen,
                     $name::BlockCommentClose => Self::BlockCommentClose,
                     $name::String(s) => Self::String(s),

--- a/src/languages/python.rs
+++ b/src/languages/python.rs
@@ -9,5 +9,5 @@ define_token_enum!(PythonToken, {
     line_comment: ["#"],
     block_comment: [],
     string: ["\"", "'"],
-    block_string: ["\"\"\"" => "\"\"\"", "'''" => "'''"]
+    block_string: [symmetric "\"\"\"", symmetric "'''"]
 });

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -26,6 +26,7 @@ enum ParseState<'a> {
     InLineComment,
     InBlockComment,
     InString(&'a str),
+    InBlockStringSymmetric(&'a str),
     InBlockString,
 }
 
@@ -109,15 +110,21 @@ where
                 };
                 matches_by_line.last_mut().unwrap().push(_match);
             }
-            (Normal, String(open), false) => state = InString(open),
-            (InString(open), String(close), false) if open == close => state = Normal,
-            (InString(_), NewLine, _) => state = Normal,
 
             (Normal, LineComment, false) => state = InLineComment,
             (InLineComment, NewLine, _) => state = Normal,
 
             (Normal, BlockCommentOpen, _) => state = InBlockComment,
             (InBlockComment, BlockCommentClose, _) => state = Normal,
+
+            (Normal, String(open), false) => state = InString(open),
+            (InString(open), String(close), false) if open == close => state = Normal,
+            (InString(_), NewLine, _) => state = Normal,
+
+            (Normal, BlockStringSymmetric(open), _) => state = InBlockStringSymmetric(open),
+            (InBlockStringSymmetric(open), BlockStringSymmetric(close), _) if open == close => {
+                state = Normal
+            }
 
             (Normal, BlockStringOpen, _) => state = InBlockString,
             (InBlockComment, BlockStringClose, _) => state = Normal,


### PR DESCRIPTION
This resolves the issue where both opening and closing block string delimiters in python were parsed as closing, so block strings were not respected.