### PR TITLE
feat: simd matcher

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,6 @@
+[build]
+rustflags = ["-C", "target-cpu=native"]
+
 [target.x86_64-apple-darwin]
 rustflags = [
   "-C", "link-arg=-undefined",

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -1,17 +1,24 @@
 use blink_pairs::parser::{parse_filetype, ParseState};
+use blink_pairs::simd::simd_parse_c;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("parse - rust", |b| {
-        let text = include_str!("./languages/rust.rs");
+    c.bench_function("parse simd - c", |b| {
+        let text = include_str!("./languages/c.c");
         let lines = text.lines().collect::<Vec<_>>();
-        b.iter(|| parse_filetype("rust", black_box(&lines), ParseState::Normal))
+        b.iter(|| simd_parse_c(black_box(&lines)))
     });
 
     c.bench_function("parse - c", |b| {
         let text = include_str!("./languages/c.c");
         let lines = text.lines().collect::<Vec<_>>();
         b.iter(|| parse_filetype("c", black_box(&lines), ParseState::Normal))
+    });
+
+    c.bench_function("parse - rust", |b| {
+        let text = include_str!("./languages/rust.rs");
+        let lines = text.lines().collect::<Vec<_>>();
+        b.iter(|| parse_filetype("rust", black_box(&lines), ParseState::Normal))
     });
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(portable_simd)]
+
 use buffer::ParsedBuffer;
 use mlua::prelude::*;
 use std::collections::HashMap;
@@ -8,6 +10,7 @@ use parser::Match;
 pub mod buffer;
 pub mod languages;
 pub mod parser;
+pub mod simd;
 
 static PARSED_BUFFERS: LazyLock<Mutex<HashMap<usize, ParsedBuffer>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));

--- a/src/simd.rs
+++ b/src/simd.rs
@@ -1,0 +1,214 @@
+use std::simd::{cmp::SimdPartialEq, Simd};
+
+type SimdVec = Simd<u8, 32>;
+
+pub enum SimdState {
+    Normal,
+    InString(SimdToken),
+}
+
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum SimdToken {
+    None = 0,
+    NewLine = 1,
+    Escape = 2,
+
+    CurlyBraceOpen = 3,
+    CurlyBraceClose = 4,
+    SquareBracketOpen = 5,
+    SquareBracketClose = 6,
+    ParenthesisOpen = 7,
+    ParenthesisClose = 8,
+
+    SingleQuote = 9,
+    DoubleQuote = 10,
+}
+
+impl From<SimdToken> for u8 {
+    fn from(val: SimdToken) -> Self {
+        val as u8
+    }
+}
+
+impl From<u8> for SimdToken {
+    fn from(val: u8) -> Self {
+        if val > 10 {
+            panic!("Invalid token value: {}", val);
+        }
+        // Safety: We've verified val is in range
+        unsafe { std::mem::transmute(val) }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SimdMatch {
+    pub token: SimdToken,
+    pub col: usize,
+}
+
+pub fn simd_parse_c(lines: &[&str]) -> Option<Vec<Vec<SimdMatch>>> {
+    // Tokens
+    let none_token = SimdVec::splat(SimdToken::None.into());
+
+    let new_line_token = SimdVec::splat(SimdToken::NewLine.into());
+    let new_line = SimdVec::splat(b'\n');
+
+    let escape_token = SimdVec::splat(SimdToken::Escape.into());
+    let escape = SimdVec::splat(b'\\');
+
+    let curly_brace_open_token = SimdVec::splat(SimdToken::CurlyBraceOpen.into());
+    let curly_brace_open = SimdVec::splat(b'{');
+
+    let curly_brace_close_token = SimdVec::splat(SimdToken::CurlyBraceClose.into());
+    let curly_brace_close = SimdVec::splat(b'}');
+
+    let square_bracket_open_token = SimdVec::splat(SimdToken::SquareBracketOpen.into());
+    let square_bracket_open = SimdVec::splat(b'[');
+
+    let square_bracket_close_token = SimdVec::splat(SimdToken::SquareBracketClose.into());
+    let square_bracket_close = SimdVec::splat(b']');
+
+    let round_bracket_open_token = SimdVec::splat(SimdToken::ParenthesisOpen.into());
+    let round_bracket_open = SimdVec::splat(b'(');
+
+    let round_bracket_close_token = SimdVec::splat(SimdToken::ParenthesisClose.into());
+    let round_bracket_close = SimdVec::splat(b')');
+
+    let single_quote_token = SimdVec::splat(SimdToken::SingleQuote.into());
+    let single_quote = SimdVec::splat(b'\'');
+
+    let double_quote_token = SimdVec::splat(SimdToken::DoubleQuote.into());
+    let double_quote = SimdVec::splat(b'"');
+
+    // State
+
+    let mut matches_by_line = Vec::with_capacity(lines.len());
+    matches_by_line.push(vec![]);
+
+    let mut escaped = false;
+
+    let mut state = SimdState::Normal;
+
+    for (idx, chunk) in lines
+        .join("\n")
+        .as_bytes()
+        .chunks(SimdVec::LEN)
+        .map(SimdVec::load_or_default)
+        .enumerate()
+    {
+        let mut tokens = none_token;
+
+        tokens = tokens | new_line.simd_eq(chunk).select(new_line_token, tokens);
+        tokens = tokens | escape.simd_eq(chunk).select(escape_token, tokens);
+
+        tokens = tokens
+            | curly_brace_open
+                .simd_eq(chunk)
+                .select(curly_brace_open_token, tokens);
+        tokens = tokens
+            | curly_brace_close
+                .simd_eq(chunk)
+                .select(curly_brace_close_token, tokens);
+
+        tokens = tokens
+            | square_bracket_open
+                .simd_eq(chunk)
+                .select(square_bracket_open_token, tokens);
+        tokens = tokens
+            | square_bracket_close
+                .simd_eq(chunk)
+                .select(square_bracket_close_token, tokens);
+
+        tokens = tokens
+            | round_bracket_open
+                .simd_eq(chunk)
+                .select(round_bracket_open_token, tokens);
+        tokens = tokens
+            | round_bracket_close
+                .simd_eq(chunk)
+                .select(round_bracket_close_token, tokens);
+
+        tokens = tokens
+            | single_quote
+                .simd_eq(chunk)
+                .select(single_quote_token, tokens);
+        tokens = tokens
+            | double_quote
+                .simd_eq(chunk)
+                .select(double_quote_token, tokens);
+
+        // Apply parsed tokens
+        let chunk_col = idx * SimdVec::LEN;
+        for (idx_in_chunk, token) in tokens.to_array().into_iter().enumerate() {
+            use SimdState::*;
+
+            match (&state, token.into(), escaped) {
+                (_, SimdToken::None, _) => escaped = false,
+
+                // Newline
+                (_, SimdToken::NewLine, _) => {
+                    matches_by_line.push(vec![]);
+                    escaped = false;
+                    if matches!(state, InString(_)) {
+                        state = Normal;
+                    }
+                }
+                // Escaped
+                (_, SimdToken::Escape, _) => escaped = !escaped,
+
+                // Strings
+                (Normal, SimdToken::SingleQuote, false) => state = InString(SimdToken::SingleQuote),
+                (InString(SimdToken::SingleQuote), SimdToken::SingleQuote, false) => state = Normal,
+                (Normal, SimdToken::DoubleQuote, false) => state = InString(SimdToken::DoubleQuote),
+                (InString(SimdToken::DoubleQuote), SimdToken::DoubleQuote, false) => state = Normal,
+
+                // Delimiter
+                (Normal, token, false) => matches_by_line.last_mut().unwrap().push(SimdMatch {
+                    token,
+                    col: chunk_col + idx_in_chunk,
+                }),
+
+                // No match
+                _ => escaped = false,
+            };
+        }
+    }
+
+    Some(matches_by_line)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_curly_braces() {
+        let lines = vec!["{}"];
+        let matches_by_line = simd_parse_c(&lines).unwrap();
+        assert_eq!(matches_by_line.len(), 1);
+        assert_eq!(matches_by_line[0].len(), 2);
+        assert_eq!(
+            matches_by_line[0][0],
+            SimdMatch {
+                token: SimdToken::CurlyBraceOpen.into(),
+                col: 0
+            }
+        );
+        assert_eq!(
+            matches_by_line[0][1],
+            SimdMatch {
+                token: SimdToken::CurlyBraceClose.into(),
+                col: 1
+            }
+        )
+    }
+
+    #[test]
+    fn test_ignore_strings() {
+        let lines = vec!["\"{\""];
+        let matches_by_line = simd_parse_c(&lines).unwrap();
+        assert_eq!(matches_by_line.len(), 1);
+        assert_eq!(matches_by_line[0].len(), 0);
+    }
+}


### PR DESCRIPTION
> saghen: hear me out, we write a macro that generates simd...
> stefan: now where have I heard that one before... 🤔 

Doesn't handle multiple character delimiters, has many more edge cases, and the performance is practically pointless. But it takes 0.6ms vs 1.8ms... Very unlikely to continue this approach, but it was a fun experiment :)