### PR TITLE
feat: add mappings enable/disable api

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The behavior was inspired by [lexima.vim](https://github.com/cohama/lexima.vim) 
   --- @type blink.pairs.Config
   opts = {
     mappings = {
+      -- you can call require("blink.pairs.mappings").enable() and require("blink.pairs.mappings").disable() to enable/disable mappings at runtime
       enabled = true,
       -- see the defaults: https://github.com/Saghen/blink.pairs/blob/main/lua/blink/pairs/config/mappings.lua#L10
       pairs = {},

--- a/lua/blink/pairs/mappings.lua
+++ b/lua/blink/pairs/mappings.lua
@@ -19,6 +19,31 @@ function mappings.register(rule_definitions)
   map('<Space>', mappings.space(all_rules))
 end
 
+--- @param rule_definitions blink.pairs.RuleDefinitions
+function mappings.unregister(rule_definitions)
+  local rules_by_key = rule_lib.parse(rule_definitions)
+
+  local unmap = function(lhs) vim.keymap.del('i', lhs) end
+
+  for key, rules in pairs(rules_by_key) do
+    if #rules > 0 then unmap(key) end
+  end
+
+  unmap('<BS>')
+  unmap('<CR>')
+  unmap('<Space>')
+end
+
+function mappings.enable()
+  local config = require('blink.pairs.config')
+  mappings.register(config.mappings.pairs)
+end
+
+function mappings.disable()
+  local config = require('blink.pairs.config')
+  mappings.unregister(config.mappings.pairs)
+end
+
 function mappings.on_key(key, rules)
   return function()
     if vim.api.nvim_get_mode().mode:find('R') ~= nil then return key end


### PR DESCRIPTION
I use multiple-cursors.nvim, which need to disable autopairs at runtime

``` lua
  opts = {
    pre_hook = function()
      require("blink.pairs.mappings").disable()
    end,
    post_hook = function()
      require("blink.pairs.mappings").enable()
    end,
  },
```
so I added this feature