### PR TITLE
feat: explore nom parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,7 @@ dependencies = [
  "criterion",
  "logos",
  "mlua",
+ "nom",
  "serde",
 ]
 
@@ -387,6 +388,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ harness = false
 [dependencies]
 logos = "0.15.0"
 mlua = { version = "0.10.2", features = ["module", "luajit", "serialize"] }
+nom = "8.0.0"
 serde = { version = "1.0.219", features = ["derive"] }
 
 [dev-dependencies]

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -1,17 +1,32 @@
-use blink_pairs::parser::{parse_filetype, ParseState};
+use blink_pairs::{
+    nom,
+    parser::{parse_filetype, ParseState},
+};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("parse - rust", |b| {
-        let text = include_str!("./languages/rust.rs");
+    c.bench_function("nom - c", |b| {
+        let text = include_str!("./languages/c.c");
         let lines = text.lines().collect::<Vec<_>>();
-        b.iter(|| parse_filetype("rust", black_box(&lines), ParseState::Normal))
+        b.iter(|| {
+            let mut tokens_by_line = Vec::with_capacity(lines.len());
+            for line in black_box(&lines).iter() {
+                let (_, line_tokens) = nom::parse(line).unwrap();
+                tokens_by_line.push(line_tokens);
+            }
+        })
     });
 
     c.bench_function("parse - c", |b| {
         let text = include_str!("./languages/c.c");
         let lines = text.lines().collect::<Vec<_>>();
         b.iter(|| parse_filetype("c", black_box(&lines), ParseState::Normal))
+    });
+
+    c.bench_function("parse - rust", |b| {
+        let text = include_str!("./languages/rust.rs");
+        let lines = text.lines().collect::<Vec<_>>();
+        b.iter(|| parse_filetype("rust", black_box(&lines), ParseState::Normal))
     });
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use parser::{Match, MatchWithLine};
 
 pub mod buffer;
 pub mod languages;
+pub mod nom;
 pub mod parser;
 
 static PARSED_BUFFERS: LazyLock<Mutex<HashMap<usize, ParsedBuffer>>> =

--- a/src/nom.rs
+++ b/src/nom.rs
@@ -1,0 +1,94 @@
+use nom::{
+    branch::alt,
+    bytes::complete::tag,
+    character::anychar,
+    combinator::{not, value},
+    multi::{many0, many_till},
+    sequence::preceded,
+    IResult, Parser,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum CToken<'a> {
+    DelimiterOpen((&'a str, &'a str)),
+    DelimiterClose(&'a str),
+    LineComment,
+    BlockCommentOpen((&'a str, &'a str)),
+    BlockCommentClose(&'a str),
+    String,
+    BlockStringOpen((&'a str, &'a str)),
+    BlockStringClose(&'a str),
+    BlockStringSymmetric(&'a str),
+    Escape,
+    NonToken,
+}
+
+fn token(input: &str) -> IResult<&str, CToken> {
+    alt((
+        // DelimiterOpen
+        value(CToken::DelimiterOpen(("(", ")")), tag("(")),
+        value(CToken::DelimiterOpen(("[", "]")), tag("[")),
+        value(CToken::DelimiterOpen(("{", "}")), tag("{")),
+        // DelimiterClose
+        value(CToken::DelimiterClose(")"), tag(")")),
+        value(CToken::DelimiterClose("]"), tag("]")),
+        value(CToken::DelimiterClose("}"), tag("}")),
+        // Comments
+        value(CToken::LineComment, tag("//")),
+        value(CToken::BlockCommentOpen(("/*", "*/")), tag("/*")),
+        value(CToken::BlockCommentClose("*/"), tag("*/")),
+        // Escape
+        value(CToken::Escape, tag("\\")),
+    ))
+    .parse(input)
+}
+
+// Main parser that collects tokens and skips non-tokens
+pub fn parse(input: &str) -> IResult<&str, Vec<CToken>> {
+    let mut result = Vec::new();
+    let mut remaining = input;
+
+    while !remaining.is_empty() {
+        // Try to parse a token
+        match token(remaining) {
+            Ok((rest, token)) => {
+                result.push(token);
+                remaining = rest;
+            }
+            // If no token, skip one character
+            Err(_) => {
+                // Safe because we checked that remaining is not empty
+                let (rest, _) = anychar(remaining)?;
+                remaining = rest;
+            }
+        }
+    }
+
+    Ok(("", result))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse() {
+        assert_eq!(
+            parse(" {"),
+            Ok(("", vec![CToken::DelimiterOpen(("{", "}"))]))
+        );
+
+        assert_eq!(
+            parse("int main(int argc, char **argv) { return 0; }"),
+            Ok((
+                "",
+                vec![
+                    CToken::DelimiterOpen(("(", ")")),
+                    CToken::DelimiterClose(")"),
+                    CToken::DelimiterOpen(("{", "}")),
+                    CToken::DelimiterClose("}"),
+                ]
+            ))
+        );
+    }
+}


### PR DESCRIPTION
Performance is 2.5x slower than logos with only basic cases and no storing of matches, possibly because it has to lookahead one character for the `/*` and then we only skip over one character