### PR TITLE
fix(latex): support latex, tex and bib filetype

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -31,7 +31,7 @@ pub fn parse_filetype(
         "javascript" => Some(parse(lines, initial_state, languages::JavaScript {})),
         "json" => Some(parse(lines, initial_state, languages::Json {})),
         "kotlin" => Some(parse(lines, initial_state, languages::Kotlin {})),
-        "latex" => Some(parse(lines, initial_state, languages::Latex {})),
+        "latex" | "tex" | "bib" => Some(parse(lines, initial_state, languages::Latex {})),
         "lean" => Some(parse(lines, initial_state, languages::Lean {})),
         "lua" => Some(parse(lines, initial_state, languages::Lua {})),
         "markdown" => Some(parse(lines, initial_state, languages::Markdown {})),


### PR DESCRIPTION
In NeoVim, we need to support three common filetypes related to latex. The grammar of these three are similar, so I believe we can just support them in one *language parser*.