### PR TITLE
fix(nix): use nightly toolchain for build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -77,7 +77,7 @@
           program = let
             buildScript = pkgs.writeShellApplication {
               name = "build-plugin";
-              runtimeInputs = with pkgs; [ cargo gcc ];
+              runtimeInputs = with pkgs; [ fenix.minimal.toolchain gcc ];
               text = ''
                 export LIBRARY_PATH="${lib.makeLibraryPath [ pkgs.libiconv ]}";
                 cargo build --release


### PR DESCRIPTION
Currently, the Nix build plugin fails to compile due to the usage of nightly features such as `#![feature]`, because the shell is currently provided the stable `cargo` package from `nixpkgs`. Instead, the nightly toolchain provided by fenix should be used, [like done in blink.cmp](https://github.com/Saghen/blink.cmp/blob/f2e4f6aae833c5c2866d203666910005363779d7/flake.nix#L83).