### PR TITLE
fix: disable `'` in latex

### DIFF
--- a/lua/blink/pairs/config/mappings.lua
+++ b/lua/blink/pairs/config/mappings.lua
@@ -38,6 +38,7 @@ local mappings = {
               -- todo: replace with spans or treesitter
               -- todo: doesn't work for quote at cursor here <'a, |b>
               and (vim.bo.filetype ~= 'rust' or (char ~= '&' and char ~= '<'))
+              and not vim.list_contains({ 'bib', 'tex', 'plaintex' }, vim.bo.filetype)
           end,
         },
       },


### PR DESCRIPTION
a single `'` in latex (math environment) is used as a short for `^{\prime}`