### PR TITLE
feat: indent aware unmatched openings

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -8,7 +8,9 @@ pub struct ParsedBuffer {
 
 impl ParsedBuffer {
     pub fn parse(filetype: &str, tab_width: u8, lines: &[&str]) -> Option<Self> {
-        parse_filetype(filetype, tab_width, lines, State::Normal)
+        let mut parsed = parse_filetype(filetype, tab_width, lines, State::Normal)?;
+        parsed.calculate_stack_heights(tab_width);
+        Some(parsed)
     }
 
     pub fn reparse_range(
@@ -50,7 +52,7 @@ impl ParsedBuffer {
                 new.indent_levels[0..length].to_vec(),
             );
 
-            self.recalculate_stack_heights();
+            self.calculate_stack_heights(tab_width);
 
             true
         } else {
@@ -58,32 +60,71 @@ impl ParsedBuffer {
         }
     }
 
-    fn recalculate_stack_heights(&mut self) {
+    fn recursive_find(
+        &self,
+        token: Token,
+        line: usize,
+        col: usize,
+        stack_height: usize,
+    ) -> Vec<MatchWithLine> {
+        let matches: Vec<MatchWithLine> = self
+            .iter_from(line, col + 1)
+            .take_while(|match_| {
+                match_
+                    .stack_height
+                    .map(|sh| sh >= stack_height)
+                    .unwrap_or(true)
+            })
+            .filter(|match_| match_.stack_height == Some(stack_height) && match_.token == token)
+            .collect();
+
+        let mut all_matches = Vec::new();
+
+        for matched_opening in matches {
+            // Add the current match
+            all_matches.push(matched_opening.clone());
+
+            // Recursively find deeper matches
+            let deeper_matches = self.recursive_find(
+                token.clone(),
+                matched_opening.line,
+                matched_opening.col,
+                stack_height + 1,
+            );
+
+            // Add all deeper matches
+            all_matches.extend(deeper_matches);
+        }
+
+        all_matches
+    }
+
+    fn calculate_stack_heights(&mut self, tab_width: u8) {
+        let mut unmatched_openings: Vec<(usize, usize)> = vec![];
         let mut stack = vec![];
 
-        // TODO: prefer matching on the furthest pair for mismatched openings
-        // [ ( ( (  ) ]
-        // ^ ^      ^ ^
         // Continue to match on closest pair for mismatched closings
         // [ ( ) ) ) ]
         // ^ ^ ^     ^
-        for matches in self.matches_by_line.iter_mut() {
+        for (line, matches) in self.matches_by_line.iter_mut().enumerate() {
             'outer: for match_ in matches.iter_mut() {
                 // Opening delimiter
                 if match_.kind == Kind::Opening {
-                    stack.push(match_);
+                    stack.push((line, match_));
                 }
                 // Closing delimiter
                 else {
-                    for (i, opening) in stack.iter().enumerate().rev() {
+                    for (i, (_, opening)) in stack.iter().enumerate().rev() {
                         if opening.token == match_.token {
                             // Mark all skipped matches as unmatched
-                            for unmatched_opening in stack.splice((i + 1).., vec![]) {
-                                unmatched_opening.stack_height = None;
+                            for (unmatched_line, unmatched_opening) in
+                                stack.splice((i + 1).., vec![])
+                            {
+                                unmatched_openings.push((unmatched_line, unmatched_opening.col));
                             }
 
                             // Update stack height
-                            let opening = stack.pop().unwrap();
+                            let (_, opening) = stack.pop().unwrap();
                             opening.stack_height = Some(stack.len());
                             match_.stack_height = Some(stack.len());
                             continue 'outer;
@@ -97,8 +138,112 @@ impl ParsedBuffer {
         }
 
         // Remaining items in stack must be unmatched
-        for match_ in stack.iter_mut() {
+        for (line, match_) in stack.into_iter() {
+            unmatched_openings.push((line, match_.col));
+        }
+        unmatched_openings.sort();
+
+        // Remove stack heights for unmatched openings
+        for (line, col) in unmatched_openings.iter() {
+            let match_ = self.match_at_mut(*line, *col).unwrap();
             match_.stack_height = None;
+        }
+
+        // Prefer matching on the furthest pair for mismatched openings
+        // As is, we have matched like so:
+        // [ ( ( [] (  ) ]
+        // ^        ^  ^ ^
+        // but we want to match like:
+        // [ ( ( [] (  ) ]
+        // ^ ^         ^ ^
+        for (line, col) in unmatched_openings.into_iter().rev() {
+            self.name_me(line, col, tab_width);
+        }
+    }
+
+    /// Gets the indent level of the line, rounded down to the nearest tab width
+    pub fn indent_level(&self, line: usize, tab_width: u8) -> u8 {
+        self.indent_levels[line].div_floor(tab_width) * tab_width
+    }
+
+    pub fn name_me(&mut self, line: usize, col: usize, tab_width: u8) {
+        let indent_level = self.indent_level(line, tab_width);
+        let token = self.match_at(line, col).unwrap().token;
+        let cursor_stack_height = self.stack_height_at(line, col);
+
+        let mut matched_openings = self
+            .recursive_find(token.clone(), line, col, cursor_stack_height)
+            .iter()
+            .flat_map(|match_| self.match_pair(match_.line, match_.col))
+            .filter(|(open, close)| {
+                self.indent_level(close.line, tab_width) == indent_level
+                    && self.indent_level(close.line, tab_width)
+                        != self.indent_level(open.line, tab_width)
+            })
+            .collect::<Vec<_>>();
+        matched_openings.sort_by_key(|(_, close)| close.line);
+
+        // Find the first matched opening that has the same stack height and token
+
+        if let Some((matched_opening_with_line, _)) = matched_openings.first() {
+            // Mark matched opening as unmatched
+            let matched_opening = self
+                .match_at_mut(
+                    matched_opening_with_line.line,
+                    matched_opening_with_line.col,
+                )
+                .unwrap();
+            matched_opening.stack_height = None;
+
+            // Mark unmatched opening as matched, using the stack height from behind the match
+            // as unmatched openings lead to incorrect stack heights for the matches after them
+            // For example:
+            // [ ( ( ) ]
+            // 0   2 2 0
+            // When it should be:
+            // [ ( ( ) ]
+            // 0   1 1 0
+            // But since we're now matching on the unmatched opening, we end up with:
+            // [ ( ( ) ]
+            // 0 1   1 0
+            let new_stack_height = self.stack_height_at_backward(line, col);
+            let unmatched_opening = self.match_at_mut(line, col).unwrap();
+            unmatched_opening.stack_height = new_stack_height;
+
+            // All matches between the unmatched opening and the matched opening are now
+            // 1 stack height deeper, so we update them. For example, starting with:
+            // [ ( { } ( ) ]
+            // 0   1 1 1 1 0
+            // After the previous step, we have:
+            // [ ( { } ( ) ]
+            // 0 1 1 1   1 0
+            // So we update the "{ }" stack height by 1
+            // [ ( { } ( ) ]
+            // 0 1 2 2   1 0
+            for match_ in self.matches_by_line[line..]
+                .iter_mut()
+                .enumerate()
+                .flat_map(|(line_idx, matches)| {
+                    matches
+                        .iter_mut()
+                        .filter(move |match_| line_idx != 0 || match_.col > col)
+                })
+            {
+                if match_.stack_height == Some(cursor_stack_height)
+                    && match_.token == token
+                    && match_.kind == Kind::Closing
+                {
+                    match_.stack_height = new_stack_height;
+                    break;
+                }
+                // match_.stack_height = match_.stack_height.map(|stack_height| stack_height + 1);
+            }
+
+            self.name_me(
+                matched_opening_with_line.line,
+                matched_opening_with_line.col,
+                tab_width,
+            );
         }
     }
 
@@ -204,6 +349,13 @@ impl ParsedBuffer {
             .cloned()
     }
 
+    pub fn match_at_mut(&mut self, line_number: usize, col: usize) -> Option<&mut Match> {
+        self.matches_by_line
+            .get_mut(line_number)?
+            .iter_mut()
+            .find(|match_| (match_.col..(match_.col + match_.len())).contains(&col))
+    }
+
     pub fn match_pair(
         &self,
         line_number: usize,
@@ -261,22 +413,25 @@ impl ParsedBuffer {
         }
     }
 
+    pub fn stack_height_at_forward(&self, line_number: usize, col: usize) -> Option<usize> {
+        self.iter_from(line_number, col).find_map(|match_| {
+            match_.stack_height.map(|stack_height| {
+                stack_height + (if match_.kind == Kind::Closing { 1 } else { 0 })
+            })
+        })
+    }
+
+    pub fn stack_height_at_backward(&self, line_number: usize, col: usize) -> Option<usize> {
+        self.iter_to(line_number, col).find_map(|match_| {
+            match_.stack_height.map(|stack_height| {
+                stack_height + (if match_.kind == Kind::Opening { 1 } else { 0 })
+            })
+        })
+    }
+
     pub fn stack_height_at(&self, line_number: usize, col: usize) -> usize {
-        // Forward pass
-        self.iter_from(line_number, col)
-            .find_map(|match_| {
-                match_.stack_height.map(|stack_height| {
-                    stack_height + (if match_.kind == Kind::Closing { 1 } else { 0 })
-                })
-            })
-            // Backward pass, if needed
-            .or_else(|| {
-                self.iter_to(line_number, col).find_map(|match_| {
-                    match_.stack_height.map(|stack_height| {
-                        stack_height + (if match_.kind == Kind::Opening { 1 } else { 0 })
-                    })
-                })
-            })
+        self.stack_height_at_forward(line_number, col)
+            .or_else(|| self.stack_height_at_backward(line_number, col))
             .unwrap_or(0)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(portable_simd)]
+#![feature(int_roundings)]
 
 use mlua::prelude::*;
 use parser::matcher::TokenType;

--- a/src/parser/matcher/mod.rs
+++ b/src/parser/matcher/mod.rs
@@ -20,7 +20,6 @@ pub trait Matcher {
         &mut self,
         matches_by_line: &mut Vec<Vec<Match>>,
         matches: &mut Vec<Match>,
-        stack: &mut Vec<(usize, usize, u8)>,
         tokens: &mut MultiPeek<I>,
         state: State,
         token: CharPos,

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -30,7 +30,6 @@ pub fn parse<M: Matcher>(
     let mut state_by_line = Vec::with_capacity(lines.len());
     let mut state = initial_state;
 
-    let mut stack = vec![];
     let mut escaped_col: Option<usize> = None;
 
     let text = lines.join("\n");
@@ -78,7 +77,6 @@ pub fn parse<M: Matcher>(
         state = matcher.call(
             &mut matches_by_line,
             &mut line_matches,
-            &mut stack,
             &mut tokens,
             state,
             token,
@@ -87,11 +85,6 @@ pub fn parse<M: Matcher>(
     }
     matches_by_line.push(line_matches);
     state_by_line.push(state);
-
-    // Remaining items in stack must be unmatched
-    for (line_number, match_index, _) in stack.into_iter() {
-        matches_by_line[line_number][match_index].stack_height = None;
-    }
 
     ParsedBuffer {
         matches_by_line,


### PR DESCRIPTION
Uses the new indent levels to find the most likely match for unmatched pairs. Performance likely isn't ideal in some edge cases (such as stack_height 0). Code is extremely messy, some of the comments are now out of date.

Closes #49 