### PR TITLE
fix: try to expand abbreviations in mapping

### DIFF
--- a/lua/blink/pairs/mappings.lua
+++ b/lua/blink/pairs/mappings.lua
@@ -207,11 +207,13 @@ end
 --- @param rules blink.pairs.Rule[]
 function mappings.enter(rules)
   return function()
-    if not mappings.is_enabled() or vim.api.nvim_get_mode().mode == 'c' then return '<C-]><CR>' end
+    -- invalid in cmdline, use <C-]> to expand abbreviations
+    if vim.api.nvim_get_mode().mode == 'c' then return '<C-]><CR>' end
+    if not mappings.is_enabled() then return '<CR>' end
 
     local ctx = require('blink.pairs.context').new()
     local rule, surrounding_space = rule_lib.get_surrounding(ctx, rules, 'enter')
-    if rule == nil then return '<C-]><CR>' end
+    if rule == nil then return '<CR>' end
 
     if surrounding_space then return mappings.shift_keycode(1) .. '<BS><BS>' .. '<CR><C-o>O' end
 
@@ -226,11 +228,19 @@ end
 --- @param rules blink.pairs.Rule[]
 function mappings.space(rules)
   return function()
-    if not mappings.is_enabled() then return '<C-]><Space>' end
+    if not mappings.is_enabled() then
+      -- use <C-]> to expand abbreviations
+      if vim.api.nvim_get_mode().mode == 'c' then return '<C-]><Space>' end
+      return '<Space>'
+    end
 
     local ctx = require('blink.pairs.context').new()
     local rule = rule_lib.get_surrounding(ctx, rules, 'space')
-    if rule == nil then return '<C-]><Space>' end
+    if rule == nil then
+      -- use <C-]> to expand abbreviations
+      if vim.api.nvim_get_mode().mode == 'c' then return '<C-]><Space>' end
+      return '<Space>'
+    end
 
     -- "(|)" -> "( | )"
     return '<Space><Space>' .. mappings.shift_keycode(-1)


### PR DESCRIPTION
fixes #57

nvim would try to expand abbreviations when a non 'iskeyword' character is typed. This does not work when we have a mapping like that. However, we can send <C-]> before <Space> and <CR> to emulate this behavior.