### PR TITLE
fix: allow matchparen without rainbow bracket colorization

### DIFF
--- a/lua/blink/pairs/highlighter.lua
+++ b/lua/blink/pairs/highlighter.lua
@@ -48,6 +48,9 @@ function highlighter.register(config)
       -- start parsing, skip if unsupported
       if not watcher_attach(bufnr) then return false end
 
+      -- skip colorization if no groups defined, but keep watcher attached for matchparen
+      if type(config.groups) == 'table' and #config.groups == 0 then return false end
+
       -- buffer changed, full redraw
       local tick = nvim_buf_get_changedtick(bufnr)
       if tick ~= buf_ticks[bufnr] then


### PR DESCRIPTION
Skip colorization when `groups = {}` while keeping the watcher attached so matchparen still works independently.  This just adds a single early return in `highlighter.lua` `on_win` - after `watcher_attach` (so parsing still happens for matchparen) but before any colorization logic runs.


Closes #79