### PR TITLE
fix: respect `vim.b.pairs = false` and `disabled_filetypes` in highlighter and matchparen

### DIFF
--- a/lua/blink/pairs/highlighter.lua
+++ b/lua/blink/pairs/highlighter.lua
@@ -14,6 +14,7 @@ function highlighter.register(config)
 
   local watcher_attach = require('blink.pairs.watcher').attach
   local get_line_matches = require('blink.pairs.rust').get_line_matches
+  local mappings_config = require('blink.pairs.config').mappings
 
   local ns = config.ns
   local cmdline_enabled = config.cmdline
@@ -34,6 +35,14 @@ function highlighter.register(config)
 
   vim.api.nvim_set_decoration_provider(ns, {
     on_win = function(_, winnr, bufnr, toprow, botrow)
+      if
+        vim.b[bufnr].pairs == false
+        or vim.b[bufnr].blink_pairs == false
+        or vim.tbl_contains(mappings_config.disabled_filetypes, vim.bo[bufnr].filetype)
+      then
+        return false
+      end
+
       local is_cmdline = nvim_get_mode().mode:match('c')
       if is_cmdline then
         local is_cmdline_extui_buf = vim.bo[bufnr].filetype == 'cmd'

--- a/lua/blink/pairs/matchparen.lua
+++ b/lua/blink/pairs/matchparen.lua
@@ -7,6 +7,7 @@ function M.setup(config)
   if not (config.matchparen and config.matchparen.enabled) then return end
 
   local rust = require('blink.pairs.rust')
+  local mappings_config = require('blink.pairs.config').mappings
   local ns = vim.api.nvim_create_namespace('blink_pairs_matchparen')
   local last_buf
 
@@ -17,6 +18,14 @@ function M.setup(config)
   vim.api.nvim_create_autocmd(autocmds, {
     group = vim.api.nvim_create_augroup('BlinkPairsMatchparen', {}),
     callback = function(ev)
+      if
+        vim.b.pairs == false
+        or vim.b.blink_pairs == false
+        or vim.tbl_contains(mappings_config.disabled_filetypes, vim.bo.filetype)
+      then
+        return
+      end
+
       local mode = vim.api.nvim_get_mode().mode
       -- In insert mode, we'll get the CursorMovedI event, so we can ignore CursorMoved
       if


### PR DESCRIPTION
The decoration provider's `on_win` unconditionally called `watcher.attach`, which triggers `parse_buffer()` on first attach and sets up `nvim_buf_attach` for ongoing incremental parsing on every edit. Similarly, matchparen's autocmd called `get_match_pair()` on every cursor move. This caused significant slowdown on large files even when the user explicitly disabled the plugin for that buffer. 

As @Kaiser-Yang noted: "You should disable the highlights, which make this delay." - but users shouldn't have to globally disable highlights just to opt out specific buffers. The `vim.b.pairs` and `disabled_filetypes` settings should be sufficient.

This adds early-return checks for `vim.b.pairs`, `vim.b.blink_pairs`, and `mappings.disabled_filetypes` at the top of the highlighter's `on_win` and matchparen's `CursorMoved` callback - the same signals already used by `mappings.is_enabled()`. This prevents `watcher.attach` from ever being called on disabled buffers, so no `parse_buffer()`, no `nvim_buf_attach`, and no `get_match_pair()` work happens.

Still we have to re-verify but it should help in resolving #72