### PR TITLE
fix: correctly resolve project_root in rust.lua

### DIFF
--- a/lua/blink/pairs/rust.lua
+++ b/lua/blink/pairs/rust.lua
@@ -19,7 +19,7 @@
 --- @class blink.pairs.MatchWithLine : blink.pairs.Match
 --- @field line number
 
-local project_root = vim.fn.fnamemodify(debug.getinfo(1, 'S').source:sub(2), ':h:h:h')
+local project_root = vim.fn.fnamemodify(debug.getinfo(1, 'S').source:sub(2), ':h:h:h:h')
 local native = require('blink.lib.native')
 --- @type blink.pairs.Parser
 local rust = native.load('blink_pairs_parser', native.try_git_commit(project_root))


### PR DESCRIPTION
### Description

This PR fixes an issue where `blink_pairs_parser` fails to resolve because `project_root` is calculated incorrectly in `lua/blink/pairs/rust.lua`.

Currently, `project_root` is resolved using `:h:h:h`, which only moves three levels up from `rust.lua` and points to the `lua/` directory instead of the actual repository root:

```text
.../blink.pairs/lua
```

The expected root should be:

```text
.../blink.pairs
```

Because of this incorrect path, `native.try_git_commit(project_root)` cannot find `.git/HEAD` and returns `nil`, causing the native library resolution to fail with:

```text
Failed to resolve library in $runtimepath/lib/: blink_pairs_parser
```

### Error

```bash
Error in /Users/yjq/.config/nvim/init.lua:
E5113: Lua chunk: .../site/pack/core/opt/blink.pairs/lua/blink/pairs/rust.lua:25: Failed to resolve library in $runtimepath/lib/: blink_pairs_parser
stack traceback:
	[C]: in function 'load'
	.../site/pack/core/opt/blink.pairs/lua/blink/pairs/rust.lua:25: in main chunk
	[C]: in function 'require'
	.../core/opt/blink.pairs/lua/blink/pairs/highlight/init.lua:13: in function 'register'
	.../site/pack/core/opt/blink.pairs/lua/blink/pairs/init.lua:36: in function 'setup'
	/Users/yjq/.config/nvim/lua/plugins/blink-pairs.lua:13: in main chunk
	[C]: in function 'require'
	/Users/yjq/.config/nvim/lua/plugins/init.lua:96: in main chunk
	[C]: in function 'require'
	/Users/yjq/.config/nvim/init.lua:8: in main chunk
```

### Solution

Add one more `:h` to `vim.fn.fnamemodify`, so the path correctly moves four levels up to the repository root.

This changes the resolved path from:

```lua
':h:h:h'
```

to:

```lua
':h:h:h:h'
```

This also aligns with the approach used in `blink.cmp`’s fuzzy Rust module, where multiple `:h` segments are used to resolve the correct project root.

Thanks for your work on this great plugin!  :)