### PR TITLE
fix: only use `std::hint::cold_path` if rust is at least >= 1.95.0.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,30 @@
 fn main() {
     // delete existing version file created by blink.download
     let _ = std::fs::remove_file("target/release/version");
+
+    println!("cargo:rustc-check-cfg=cfg(have_cold_path)");
+    if std::process::Command::new("rustc")
+        .arg("--version")
+        .output()
+        .ok()
+        .is_some_and(|out| {
+            let out = String::from_utf8_lossy(&out.stdout);
+
+            if let Some(version) = out.split(" ").nth(1) // extract version component from `rustc 1.98.0-nightly (<commit_hash>)`
+                && let Some(version) = version.split("-").next() // remove any trailing tags like `-nightly`
+                && let &[major, minor, patch] = version
+                    .split(".")
+                    .filter_map(|n| str::parse::<u32>(n).ok())
+                    .collect::<Vec<_>>()
+                    .as_slice()
+            {
+                // Only enable cold_path if we know for sure that rust >= 1.95.0
+                (major, minor, patch) >= (1, 95, 0)
+            } else {
+                false
+            }
+        })
+    {
+        println!("cargo:rustc-cfg=have_cold_path");
+    }
 }

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -43,7 +43,7 @@ pub fn parse<M: Matcher>(lines: &[&str], initial_state: State, mut matcher: M) -
         let mut found_non_whitespace = false;
         for (col, &byte) in line.as_bytes().iter().enumerate() {
             if !found_non_whitespace {
-                std::hint::cold_path();
+                cold_path();
                 match byte {
                     b'\t' => tabs = tabs.saturating_add(1),
                     b' ' => spaces = spaces.saturating_add(1),
@@ -51,12 +51,12 @@ pub fn parse<M: Matcher>(lines: &[&str], initial_state: State, mut matcher: M) -
                 }
             }
             if mask[byte as usize] {
-                std::hint::cold_path();
+                cold_path();
                 tokens.push(CharPos { byte, col });
             }
         }
         if !found_non_whitespace {
-            std::hint::cold_path();
+            cold_path();
             // this line is entirely whitespace, so use the previous line's indentation.
             indents_by_line.push(last_indent.unwrap_or((tabs, spaces)));
         } else {
@@ -112,6 +112,18 @@ pub fn parse<M: Matcher>(lines: &[&str], initial_state: State, mut matcher: M) -
         indents_by_line,
         state_by_line,
     }
+}
+
+/// [`std::hint::cold_path`] intrinsic, when it is available (i.e., rust is at
+/// least 1.95.0).
+///
+/// NOTE: remove this and use [`std::hint::cold_path`] once rust 1.95.0 is
+/// sufficiently old (for instance, once it's available in debian)
+#[inline(always)]
+fn cold_path() {
+    // See build.rs for the definition of have_cold_path.
+    #[cfg(have_cold_path)]
+    std::hint::cold_path();
 }
 
 // TODO: come up with a better way to do testing


### PR DESCRIPTION
Fixes build on rust < 1.95.0.

Unfortunately, this would be much simpler to do if `![cfg(version("1.95.0"))]` was stable.