### PR TITLE
fix: ensure blink.pairs is in rtp before build (and download) on first install

### DIFF
--- a/lua/blink/pairs/init.lua
+++ b/lua/blink/pairs/init.lua
@@ -42,7 +42,7 @@ function pairs.library_available() return native:library_available() end
 --- @param opts? { force?: boolean, dev?: boolean }
 --- @return blink.lib.Task
 function pairs.build(opts)
-  return native:build(
+  local build = native:build(
     { 'cargo', 'build', '--release' },
     function(repo_root, platform)
       return {
@@ -52,13 +52,17 @@ function pairs.build(opts)
     end,
     opts
   )
+  if not vim.tbl_contains(vim.api.nvim_list_runtime_paths(), native.repo_root) then
+    vim.opt.runtimepath:append(native.repo_root)
+  end
+  return build
 end
 
 --- Downloads the precompiled library if it's not already available
 --- @param opts? { force?: boolean, dev?: boolean }
 --- @return blink.lib.Task
 function pairs.download(opts)
-  return native:download(
+  local download = native:download(
     function(git_tag, platform)
       return 'https://github.com/saghen/blink.pairs/releases/download/'
         .. git_tag
@@ -68,6 +72,10 @@ function pairs.download(opts)
     end,
     opts
   )
+  if not vim.tbl_contains(vim.api.nvim_list_runtime_paths(), native.repo_root) then
+    vim.opt.runtimepath:append(native.repo_root)
+  end
+  return download
 end
 
 -- Get match at a given position in a buffer

--- a/lua/blink/pairs/init.lua
+++ b/lua/blink/pairs/init.lua
@@ -42,7 +42,10 @@ function pairs.library_available() return native:library_available() end
 --- @param opts? { force?: boolean, dev?: boolean }
 --- @return blink.lib.Task
 function pairs.build(opts)
-  local build = native:build(
+  if not vim.tbl_contains(vim.api.nvim_list_runtime_paths(), native.repo_root) then
+    vim.opt.runtimepath:append(native.repo_root)
+  end
+  return native:build(
     { 'cargo', 'build', '--release' },
     function(repo_root, platform)
       return {
@@ -52,17 +55,16 @@ function pairs.build(opts)
     end,
     opts
   )
-  if not vim.tbl_contains(vim.api.nvim_list_runtime_paths(), native.repo_root) then
-    vim.opt.runtimepath:append(native.repo_root)
-  end
-  return build
 end
 
 --- Downloads the precompiled library if it's not already available
 --- @param opts? { force?: boolean, dev?: boolean }
 --- @return blink.lib.Task
 function pairs.download(opts)
-  local download = native:download(
+  if not vim.tbl_contains(vim.api.nvim_list_runtime_paths(), native.repo_root) then
+    vim.opt.runtimepath:append(native.repo_root)
+  end
+  return native:download(
     function(git_tag, platform)
       return 'https://github.com/saghen/blink.pairs/releases/download/'
         .. git_tag
@@ -72,10 +74,6 @@ function pairs.download(opts)
     end,
     opts
   )
-  if not vim.tbl_contains(vim.api.nvim_list_runtime_paths(), native.repo_root) then
-    vim.opt.runtimepath:append(native.repo_root)
-  end
-  return download
 end
 
 -- Get match at a given position in a buffer


### PR DESCRIPTION
fixes saghen#113

Before this fix, the parser was built correctly but failed to load. This is due to it not being in the path where the binary was searched. Quite frankly, there may be a better way to do this, but I do not have currently the time to devote to such endeavour.

below `repro.lua` shows the fix.

repro.lua
```lua
local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
if not (vim.uv or vim.loop).fs_stat(lazypath) then
	local lazyrepo = "https://github.com/folke/lazy.nvim.git"
	local out = vim.fn.system({ "git", "clone", "--filter=blob:none", "--branch=stable", lazyrepo, lazypath })
	if vim.v.shell_error ~= 0 then
		vim.api.nvim_echo({
			{ "Failed to clone lazy.nvim:\n", "ErrorMsg" },
			{ out, "WarningMsg" },
			{ "\nPress any key to exit..." },
		}, true, {})
		vim.fn.getchar()
		os.exit(1)
	end
end
vim.opt.rtp:prepend(lazypath)

vim.g.mapleader = " "
vim.g.maplocalleader = "\\"

-- Setup lazy.nvim
require("lazy").setup({
	spec = {
		{ "saghen/blink.lib" },
		{
			"sergentbne/blink.pairs",
			dependencies = "saghen/blink.lib",

			commit = "138563badbb560924e06d7e8653103141800be9e",
			build = function()
				require("blink.pairs").build():pwait(60000)
			end,
			opts = {
				mappings = {
					-- you can call require("blink.pairs.mappings").enable()
					-- and require("blink.pairs.mappings").disable()
					-- to enable/disable mappings at runtime
					enabled = true,
					cmdline = true,
					disabled_filetypes = {},
					wrap = {
						["<C-b>"] = "motion",
						["<C-S-b>"] = "motion_reverse",
					},
					pairs = {},
				},
				highlights = {
					enabled = true,
					cmdline = true,
					groups = { "BlinkPairsOrange", "BlinkPairsPurple", "BlinkPairsBlue" },
					unmatched_group = "BlinkPairsUnmatched",

					matchparen = {
						enabled = true,
						cmdline = false,
						include_surrounding = false,
						group = "BlinkPairsMatchParen",
						priority = 250,
					},
				},
				debug = false,
			},
		},
	},
	install = { colorscheme = { "habamax" } },
	checker = { enabled = true },
})
```