### PR TITLE
feat: support keys not contained in the pairs they expand to

### DIFF
--- a/lua/blink/pairs/mappings/ops.lua
+++ b/lua/blink/pairs/mappings/ops.lua
@@ -64,7 +64,7 @@ function ops.on_key(key, rules)
 
       -- Multiple characters
 
-      local index_of_key = rule.opening:find(key)
+      local index_of_key = rule.opening:find(key, 1, true)
       assert(index_of_key ~= nil, 'Key not found in rule (temporary limitation, contributions welcome!)')
       index_of_key = index_of_key - 1
 

--- a/lua/blink/pairs/mappings/ops.lua
+++ b/lua/blink/pairs/mappings/ops.lua
@@ -65,8 +65,7 @@ function ops.on_key(key, rules)
       -- Multiple characters
 
       local index_of_key = rule.opening:find(key, 1, true)
-      assert(index_of_key ~= nil, 'Key not found in rule (temporary limitation, contributions welcome!)')
-      index_of_key = index_of_key - 1
+      index_of_key = index_of_key ~= nil and index_of_key - 1 or 0
 
       local opening_prefix = rule.opening:sub(1, index_of_key)
 


### PR DESCRIPTION
There is a limitation in `ops.lua` which prevents keys to expand into pairs which don't contained said key. For instance one cannot expand `$` in LaTeX files to `\(` and `\)`. I tried to remediate to this just by setting the `index_of_key` to 0 if it is not found, which worked well; I tested several such snippets and all seem to work.

I also encountered a bug when the key could be interpreted as a lua pattern in the `string.find` call, but this function supports a fourth boolean argument to specify whether the character is literal or not, so I added this commit as well.