### PR TITLE
fix: use global namespace for highlight definitions

### DIFF
--- a/plugin/blink-pairs.lua
+++ b/plugin/blink-pairs.lua
@@ -1,10 +1,9 @@
 local function set_highlights()
-  local ns = vim.api.nvim_create_namespace('blink_pairs')
-  vim.api.nvim_set_hl(ns, 'BlinkPairsOrange', { ctermfg = 15, fg = '#d65d0e', default = true })
-  vim.api.nvim_set_hl(ns, 'BlinkPairsPurple', { ctermfg = 13, fg = '#b16286', default = true })
-  vim.api.nvim_set_hl(ns, 'BlinkPairsBlue', { ctermfg = 12, fg = '#458588', default = true })
-  vim.api.nvim_set_hl(ns, 'BlinkPairsUnmatched', { ctermfg = 9, fg = '#ff007c', default = true })
-  vim.api.nvim_set_hl(ns, 'BlinkPairsMatchParen', { link = 'MatchParen', default = true })
+  vim.api.nvim_set_hl(0, 'BlinkPairsOrange', { ctermfg = 15, fg = '#d65d0e', default = true })
+  vim.api.nvim_set_hl(0, 'BlinkPairsPurple', { ctermfg = 13, fg = '#b16286', default = true })
+  vim.api.nvim_set_hl(0, 'BlinkPairsBlue', { ctermfg = 12, fg = '#458588', default = true })
+  vim.api.nvim_set_hl(0, 'BlinkPairsUnmatched', { ctermfg = 9, fg = '#ff007c', default = true })
+  vim.api.nvim_set_hl(0, 'BlinkPairsMatchParen', { link = 'MatchParen', default = true })
 end
 
 set_highlights()


### PR DESCRIPTION
Highlights defined in non-global namespace without activation

`plugin/blink-pairs.lua` sets highlights in a non-zero namespace (`blink_pairs`) but never activates it. The renderer resolves from namespace 0, so rainbow colors never appear.

Fix: use namespace 0 for `nvim_set_hl` calls. This is standard, gitsigns, telescope, mini.nvim, and treesitter all define highlights globally. Namespaced highlights are invisible to `:highlight` and `nvim_set_hl(0, ...)`, which is how users customize them.

Closes #121
