### PR TITLE
fix: add open, close and open_or_close field for config validation

### DIFF
--- a/lua/blink/pairs/config/mappings.lua
+++ b/lua/blink/pairs/config/mappings.lua
@@ -139,6 +139,9 @@ return {
             languages = { types.list('string'), 'nil' },
             when = { 'function', 'nil' },
             enter = { 'boolean', 'function', 'nil' },
+            open = { 'boolean', 'function', 'nil' },
+            close = { 'boolean', 'function', 'nil' },
+            open_or_close = { 'boolean', 'function', 'nil' },
             backspace = { 'boolean', 'function', 'nil' },
             space = { 'boolean', 'function', 'nil' },
           })


### PR DESCRIPTION
These fields were missing from the config validation, thus couldn't be used at all.