### PR TITLE
fix: verify the trigger key is the right one before expanding a pair

### DIFF
--- a/lua/blink/pairs/mappings/ops.lua
+++ b/lua/blink/pairs/mappings/ops.lua
@@ -64,15 +64,17 @@ function ops.on_key(key, rules)
 
       -- Multiple characters
 
-      local index_of_key = rule.opening:find(key, 1, true)
-      index_of_key = index_of_key ~= nil and index_of_key - 1 or 0
+      if key == rule.key then
+        local index_of_key = rule.opening:find(key, 1, true)
+        index_of_key = index_of_key ~= nil and index_of_key - 1 or 0
 
-      local opening_prefix = rule.opening:sub(1, index_of_key)
+        local opening_prefix = rule.opening:sub(1, index_of_key)
 
-      -- I.e. user types '"' for line 'r#|', we expand to 'r#""#'
-      -- or the pair is "'''", in which case the index_of_key is 0 because there's no relevant prefix
-      if index_of_key == 0 or ctx:is_before_cursor(opening_prefix) then
-        return ops.open_pair(ctx, key, rule, index_of_key + 1)
+        -- I.e. user types '"' for line 'r#|', we expand to 'r#""#'
+        -- or the pair is "'''", in which case the index_of_key is 0 because there's no relevant prefix
+        if index_of_key == 0 or ctx:is_before_cursor(opening_prefix) then
+          return ops.open_pair(ctx, key, rule, index_of_key + 1)
+        end
       end
 
       --- I.e. for line 'r#"', user types '"' to close the pair

--- a/lua/blink/pairs/rule.lua
+++ b/lua/blink/pairs/rule.lua
@@ -2,6 +2,7 @@
 --- @field priority number
 --- @field opening string
 --- @field closing string
+--- @field key string
 --- @field when fun(ctx: blink.pairs.Context): boolean
 --- @field open fun(ctx: blink.pairs.Context): boolean
 --- @field close fun(ctx: blink.pairs.Context): boolean
@@ -79,6 +80,7 @@ end
 function M.rule_from_def(key, def)
   if type(def) == 'string' then
     return {
+      key = key,
       opening = key,
       closing = def,
       priority = #key + #def,
@@ -106,6 +108,7 @@ function M.rule_from_def(key, def)
 
   return {
     priority = def.priority or priority,
+    key = key,
     closing = closing,
     opening = opening,
     when = when,


### PR DESCRIPTION
In my config, I expand `$` to `\(` and `\)` in $\LaTeX$; however, typing a single backslash expands the pair while this should only happen when I type `$` and not the starting character of the pair. Hence I added a check to verify the typed key is the trigger key.