### PR TITLE
feat: add sh, bash and fish to options

### DIFF
--- a/src/parser/languages/shell.rs
+++ b/src/parser/languages/shell.rs
@@ -8,5 +8,5 @@ define_matcher!(Shell {
         "{" => "}"
     ],
     line_comment: ["#"],
-    string: ["\"", "'"]
+    block_string: ["\"" => "\"", "'" => "'"],
 });

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -13,7 +13,7 @@ const FILETYPES: &[&str] = &[
     "haxe", "java", "javascript", "typescript", "typescriptreact", "javascriptreact", "json",
     "kotlin", "latex", "tex", "bib", "lean", "lua", "markdown", "nix", "objc", "ocaml", "perl",
     "php", "python", "r", "ruby", "rust", "scala", "scheme", "sh", "shell", "sql", "swift", "toml", "typst",
-    "vim", "zig"
+    "vim", "zig", "zsh"
 ];
 
 pub fn supports_filetype(filetype: &str) -> bool {
@@ -59,7 +59,7 @@ pub fn parse_filetype(
         "rust" => Some(parse(lines, initial_state, languages::Rust {})),
         "scala" => Some(parse(lines, initial_state, languages::Scala {})),
         "scheme" => Some(parse(lines, initial_state, languages::Scheme {})),
-        "bash" | "fish" | "sh" | "shell" => Some(parse(lines, initial_state, languages::Shell {})),
+        "bash" | "fish" | "sh" | "zsh" => Some(parse(lines, initial_state, languages::Shell {})),
         "sql" => Some(parse(lines, initial_state, languages::Sql {})),
         "swift" => Some(parse(lines, initial_state, languages::Swift {})),
         "toml" => Some(parse(lines, initial_state, languages::Toml {})),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9,11 +9,11 @@ use crate::buffer::ParsedBuffer;
 
 #[rustfmt::skip]
 const FILETYPES: &[&str] = &[
-    "c", "clojure", "cpp", "csharp", "dart", "elixir", "erlang", "fennel", "fsharp", "go", "haskell",
+    "bash", "c", "clojure", "cpp", "csharp", "dart", "elixir", "erlang", "fennel", "fish", "fsharp", "go", "haskell",
     "haxe", "java", "javascript", "typescript", "typescriptreact", "javascriptreact", "json",
     "kotlin", "latex", "tex", "bib", "lean", "lua", "markdown", "nix", "objc", "ocaml", "perl",
-    "php", "python", "r", "ruby", "rust", "scala", "scheme", "shell", "sql", "swift", "toml", "typst", "vim",
-    "zig"
+    "php", "python", "r", "ruby", "rust", "scala", "scheme", "sh", "shell", "sql", "swift", "toml", "typst",
+    "vim", "zig"
 ];
 
 pub fn supports_filetype(filetype: &str) -> bool {
@@ -59,7 +59,7 @@ pub fn parse_filetype(
         "rust" => Some(parse(lines, initial_state, languages::Rust {})),
         "scala" => Some(parse(lines, initial_state, languages::Scala {})),
         "scheme" => Some(parse(lines, initial_state, languages::Scheme {})),
-        "shell" => Some(parse(lines, initial_state, languages::Shell {})),
+        "bash" | "fish" | "sh" | "shell" => Some(parse(lines, initial_state, languages::Shell {})),
         "sql" => Some(parse(lines, initial_state, languages::Sql {})),
         "swift" => Some(parse(lines, initial_state, languages::Swift {})),
         "toml" => Some(parse(lines, initial_state, languages::Toml {})),


### PR DESCRIPTION
In neovim (obviously ;) ), the plugin doesn't work in `*.sh` files. Neovim registers these files as filetype=sh (an not shell). This PR attempts to reconcile this though it may be overly liberal here (i believe only fish and sh are necessary).

AI disclaimer: there is no human written code in this pr, which is kinda silly i know because of how simple the pr is